### PR TITLE
Add the replication worker count to #subscriptions

### DIFF
--- a/lib/pg/logical_replication/client.rb
+++ b/lib/pg/logical_replication/client.rb
@@ -142,9 +142,10 @@ module PG
 
       # Shows status and basic information about all subscriptions
       #
-      # @return [Hash] a hash with the subscription information
+      # @return [Array<Hash>] a list of subscriptions
       #   keys:
       #     subscription_name
+      #     database_name
       #     owner
       #     worker_count
       #     enabled

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -159,6 +159,14 @@ describe PG::LogicalReplication::Client do
       sub_client.create_subscription(sub_name, subscription_conninfo, [pub_name], sub_options)
     end
 
+    describe "#subscriptions" do
+      it "filters the subscriptions by database name" do
+        expect(sub_client.subscriptions.count).to eq(1)
+        expect(sub_client.subscriptions("foo").count).to eq(0)
+        expect(sub_client.subscriptions("logical_test_target").count).to eq(1)
+      end
+    end
+
     describe "#subscriber?" do
       it "returns true if there is a subscription" do
         expect(sub_client.subscriber?).to be true
@@ -177,8 +185,9 @@ describe PG::LogicalReplication::Client do
 
         sub = subs.first
         expect(sub["subscription_name"]).to eq(sub_name)
-        expect(sub["publications"]).to eq([pub_name])
+        expect(sub["database_name"]).to eq("logical_test_target")
         expect(sub["enabled"]).to be true
+        expect(sub["publications"]).to eq([pub_name])
       end
     end
 


### PR DESCRIPTION
This count will give us a more detailed status of the subscription
  - 0 workers & enabled  => subscription is down (in conflict)
  - 1 worker & enabled   => subscription is replicating
  - \>1 worker & enabled  => subscription is initializing
  - 0 workers & disabled => subscription is disabled

Before this change all we knew was if the subscription was enabled
or disabled. We couldn't tell if the subscription was running
correctly or not.