### PR TITLE
[Client] Cache type maps for queries/results

### DIFF
--- a/lib/pg/logical_replication/client.rb
+++ b/lib/pg/logical_replication/client.rb
@@ -6,6 +6,14 @@ module PG
       attr_reader :connection
       attr_reader :command_builder
 
+      def self.type_map_for_queries(connection)
+        @type_map_for_queries ||= PG::BasicTypeMapForQueries.new(connection)
+      end
+
+      def self.type_map_for_results(connection)
+        @type_map_for_results ||= PG::BasicTypeMapForResults.new(connection)
+      end
+
       # @param connection [PG::Connection] Database Connection
       def initialize(connection)
         @connection      = connection
@@ -313,16 +321,8 @@ module PG
       end
 
       def typed_exec(sql, *params)
-        result = connection.async_exec(sql, params, nil, type_map_for_queries)
-        result.map_types!(type_map_for_results)
-      end
-
-      def type_map_for_queries
-        @type_map_for_queries ||= PG::BasicTypeMapForQueries.new(connection)
-      end
-
-      def type_map_for_results
-        @type_map_for_results ||= PG::BasicTypeMapForResults.new(connection)
+        result = connection.async_exec(sql, params, nil, self.class.type_map_for_queries(connection))
+        result.map_types!(self.class.type_map_for_results(connection))
       end
     end
   end

--- a/lib/pg/logical_replication/client.rb
+++ b/lib/pg/logical_replication/client.rb
@@ -313,8 +313,16 @@ module PG
       end
 
       def typed_exec(sql, *params)
-        result = connection.async_exec(sql, params, nil, PG::BasicTypeMapForQueries.new(connection))
-        result.map_types!(PG::BasicTypeMapForResults.new(connection))
+        result = connection.async_exec(sql, params, nil, type_map_for_queries)
+        result.map_types!(type_map_for_results)
+      end
+
+      def type_map_for_queries
+        @type_map_for_queries ||= PG::BasicTypeMapForQueries.new(connection)
+      end
+
+      def type_map_for_results
+        @type_map_for_results ||= PG::BasicTypeMapForResults.new(connection)
       end
     end
   end


### PR DESCRIPTION
Since there is a very good chance (probably 100%) this will never change within the context of the same process, caching these should be safe, and save excessive queries from being executed where the data is generated.