### PR TITLE
Support providing the db name to the subscriber? method

### DIFF
--- a/lib/pg/logical_replication/client.rb
+++ b/lib/pg/logical_replication/client.rb
@@ -203,8 +203,8 @@ module PG
       # Returns if this database is subscribing to any publications
       #
       # @return [Boolean] true if there are any subscriptions, false otherwise
-      def subscriber?
-        subscriptions.any?
+      def subscriber?(dbname = nil)
+        subscriptions(dbname).any?
       end
 
       # Lists the current publications

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -172,6 +172,23 @@ describe PG::LogicalReplication::Client do
         expect(sub_client.subscriber?).to be true
       end
 
+      # Databases on the same cluster share the subscription information
+      it "returns true from publisher" do
+        expect(pub_client.subscriber?).to be true
+      end
+
+      it "returns true from subscriber if subscriber database specified" do
+        expect(sub_client.subscriber?(sub_connection.db)).to be true
+      end
+
+      it "returns false from subscriber if publisher database specified" do
+        expect(sub_client.subscriber?(pub_connection.db)).to be false
+      end
+
+      it "returns false from publisher if publisher database specified" do
+        expect(pub_client.subscriber?(pub_connection.db)).to be false
+      end
+
       it "returns false if there are no subscriptions" do
         sub_client.drop_subscription(sub_name)
         expect(sub_client.subscriber?).to be false


### PR DESCRIPTION
Previously, subscriber? provides strange results when you have the subscriptions
and publications in different databases on the same database cluster.

sub.subscriber? was true as expected
pub.subscriber? was also true and not expected

Now, we you can provide the db name to clarify which database you're asking if
they are a subscriber.

sub.subscriber?(sub.db) is now true as expected
pub.subscriber?(pub.db) is NOW false since the subscription is not created in
the pub.db.

The existing default of nil dbname is kept to avoid a backward incompatible
change.