### PR TITLE
Support local logical replication: Add create replication slot

### DIFF
--- a/lib/pg/logical_replication/client.rb
+++ b/lib/pg/logical_replication/client.rb
@@ -76,6 +76,13 @@ module PG
         typed_exec("DROP SUBSCRIPTION#{" IF EXISTS" if ifexists} #{connection.quote_ident(name)}")
       end
 
+      # Creates a logical replication slot
+      #
+      # @param name [String] logical replication slot name
+      def create_logical_replication_slot(name)
+        typed_exec("SELECT pg_create_logical_replication_slot(#{connection.escape_literal(name)}, 'pgoutput')")
+      end
+
       # Updates a subscription connection string
       #
       # @param name [String] subscription name
@@ -205,6 +212,22 @@ module PG
       # @return [Boolean] true if there are any subscriptions, false otherwise
       def subscriber?(dbname = nil)
         subscriptions(dbname).any?
+      end
+
+      # Lists the current replication slots
+      #
+      # @return [Array<String>] replication slots
+      def replication_slots
+        typed_exec(<<-SQL)
+          SELECT
+            slot_name::TEXT,
+            plugin::TEXT,
+            slot_type::TEXT,
+            database::TEXT,
+            temporary,
+            active
+          FROM pg_replication_slots
+        SQL
       end
 
       # Lists the current publications

--- a/lib/pg/logical_replication/client.rb
+++ b/lib/pg/logical_replication/client.rb
@@ -83,6 +83,13 @@ module PG
         typed_exec("SELECT pg_create_logical_replication_slot(#{connection.escape_literal(name)}, 'pgoutput')")
       end
 
+      # Drops the physical or logical replication slot.  Note, you must be on the same database a logical slot was created.
+      #
+      # @param name [String] replication slot name
+      def drop_replication_slot(name)
+        typed_exec("SELECT pg_drop_replication_slot(#{connection.escape_literal(name)})")
+      end
+
       # Updates a subscription connection string
       #
       # @param name [String] subscription name

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -151,7 +151,7 @@ describe PG::LogicalReplication::Client do
     # subscription.
     # See: https://www.postgresql.org/docs/10/sql-createsubscription.html
     def create_subscription
-      pub_connection.async_exec("select pg_create_logical_replication_slot('#{sub_name}', 'pgoutput')")
+      pub_client.create_logical_replication_slot(sub_name)
       sub_options = {
         'create_slot' => false,
         'slot_name'   => sub_name
@@ -213,6 +213,13 @@ describe PG::LogicalReplication::Client do
         sub_client.drop_subscription(sub_name)
         expect(sub_client.subscriptions.count).to eq(0)
         expect { sub_client.drop_subscription(sub_name, true) }.not_to raise_error
+      end
+    end
+
+    describe "#create_logical_replication_slot" do
+      it "creates a logical replication slot with the given name" do
+        pub_client.create_logical_replication_slot("test_create")
+        expect(pub_client.replication_slots.field_values("slot_name")).to include("test_create")
       end
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -223,6 +223,14 @@ describe PG::LogicalReplication::Client do
       end
     end
 
+    describe "#drop_replication_slot" do
+      it "drops the logical replication slot with the given name" do
+        pub_client.create_logical_replication_slot("test_drop")
+        pub_client.drop_replication_slot("test_drop")
+        expect(pub_client.replication_slots.field_values("slot_name")).not_to include("test_drop")
+      end
+    end
+
     describe "#set_subscription_conninfo" do
       it "alters the subscription conninfo string" do
         new_conninfo = subscription_conninfo.merge({"fallback_application_name" => "things"})


### PR DESCRIPTION
This is needed in order to setup local logical replication with multiple databases in the same database cluster. It's already described in good detail in the [test](https://github.com/ManageIQ/pg-logical_replication/blob/0a378bbd9ba9064dfe13f70d14c559656359d3c6/spec/client_spec.rb#L148-L152).  

The client needs to expose a way to create a slot in the publisher database separately from the subscription created in the subscriber database just as it is done in that test.