### PR TITLE
Drop end of life rubies from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.4.5
-- 2.5.3
+- 3.0.1
+- 2.7.3
+- 2.6.7
 before_install:
 - 'echo ''gem: --no-ri --no-rdoc --no-document'' > ~/.gemrc'
 - gem install bundler


### PR DESCRIPTION
Ruby 2.4 was EOL: 3/31/2020
Ruby 2.5 was EOL: 3/31/2021

These rubies will still work for now but will soon no longer work since we're
not testing with them anymore.