### PR TITLE
Add ruby 3.2+ support drop 2.5 through 2.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.5'
-        - '2.6'
-        - '2.7'
         - '3.0'
         - '3.1'
+        - '3.2'
+        - '3.3'
     services:
       postgres:
         image: manageiq/postgresql:13
@@ -44,7 +43,7 @@ jobs:
       run: bundle exec rake
       env:
         CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
-    - if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.1' }}
+    - if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.3' }}
       name: Report code coverage
       continue-on-error: true
       uses: paambaati/codeclimate-action@v9

--- a/pg-logical_replication.gemspec
+++ b/pg-logical_replication.gemspec
@@ -24,7 +24,7 @@ This gem provides a class with methods which map directly to the PostgreSQL DSL 
   spec.add_dependency "pg"
 
   spec.add_development_dependency "manageiq-style"
-  spec.add_development_dependency "rake",          "~> 10.0"
+  spec.add_development_dependency "rake",          ">= 12.3.2"
   spec.add_development_dependency "rspec",         "~> 3.0"
   spec.add_development_dependency "simplecov",     ">= 0.21.2"
 end


### PR DESCRIPTION
### Add ruby 3.2+ support with rake tasks

Fixes "NoMethodError: undefined method `=~' for #<Proc...lib/rake/application.rb..." when running rake.

Reported in https://github.com/ruby/rake/issues/431
Fixed in: https://github.com/ruby/rake/pull/297

### Drop far EOL ruby 2.5-2.7, add 3.2, 3.3

